### PR TITLE
feat(arrow-down): fix s & m, add l, xl & xxl

### DIFF
--- a/icons/ui/icon_arrow-down_l_black.svg
+++ b/icons/ui/icon_arrow-down_l_black.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_l_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-51.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-3" transform="translate(51.000000, 0.000000)">
-                    <polygon id="Fill-6" points="0 30 30 30 30 0 0 0"></polygon>
-                    <polygon id="Stroke-5" fill="#000000" fill-rule="nonzero" points="14.89203 17.1858632 20.4314466 11.6464466 21.1385534 12.3535534 14.89197 18.6001368 8.64641661 12.3535234 9.35358339 11.6464766"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="30" height="30" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_l_black</title><g fill="none" fill-rule="evenodd"><path d="M0 30h30V0H0z"/><path fill="#000" fill-rule="nonzero" d="M14.892 17.186l5.54-5.54.707.708-6.247 6.246-6.246-6.246.708-.708z"/></g></svg>

--- a/icons/ui/icon_arrow-down_l_black.svg
+++ b/icons/ui/icon_arrow-down_l_black.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_l_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-51.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-3" transform="translate(51.000000, 0.000000)">
+                    <polygon id="Fill-6" points="0 30 30 30 30 0 0 0"></polygon>
+                    <polygon id="Stroke-5" fill="#000000" fill-rule="nonzero" points="14.89203 17.1858632 20.4314466 11.6464466 21.1385534 12.3535534 14.89197 18.6001368 8.64641661 12.3535234 9.35358339 11.6464766"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_l_white.svg
+++ b/icons/ui/icon_arrow-down_l_white.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_l_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-51.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-3" transform="translate(51.000000, 0.000000)">
-                    <polygon id="Fill-6" points="0 30 30 30 30 0 0 0"></polygon>
-                    <polygon id="Stroke-5" fill="#FFFFFF" fill-rule="nonzero" points="14.89203 17.1858632 20.4314466 11.6464466 21.1385534 12.3535534 14.89197 18.6001368 8.64641661 12.3535234 9.35358339 11.6464766"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="30" height="30" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_l_black</title><g fill="none" fill-rule="evenodd"><path d="M0 30h30V0H0z"/><path fill="#FFF" fill-rule="nonzero" d="M14.892 17.186l5.54-5.54.707.708-6.247 6.246-6.246-6.246.708-.708z"/></g></svg>

--- a/icons/ui/icon_arrow-down_l_white.svg
+++ b/icons/ui/icon_arrow-down_l_white.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_l_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-51.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-3" transform="translate(51.000000, 0.000000)">
+                    <polygon id="Fill-6" points="0 30 30 30 30 0 0 0"></polygon>
+                    <polygon id="Stroke-5" fill="#FFFFFF" fill-rule="nonzero" points="14.89203 17.1858632 20.4314466 11.6464466 21.1385534 12.3535534 14.89197 18.6001368 8.64641661 12.3535234 9.35358339 11.6464766"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_m_black.svg
+++ b/icons/ui/icon_arrow-down_m_black.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"/><path fill="#0B1F35" d="M24 7.087l-1.082-.973L12 15.941 1.082 6.114 0 7.087l12 10.799z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_m_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-22.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-2" transform="translate(22.000000, 0.000000)">
+                    <polygon id="Fill-4" points="0 24 24 24 24 0 0 0"></polygon>
+                    <polygon id="Stroke-3" fill="#000000" fill-rule="nonzero" points="16.0744091 9.64648411 16.7815909 10.3535159 11.714 15.4221818 6.64640912 10.3535159 7.35359088 9.64648411 11.714 14.0078182"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_m_black.svg
+++ b/icons/ui/icon_arrow-down_m_black.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_m_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-22.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-2" transform="translate(22.000000, 0.000000)">
-                    <polygon id="Fill-4" points="0 24 24 24 24 0 0 0"></polygon>
-                    <polygon id="Stroke-3" fill="#000000" fill-rule="nonzero" points="16.0744091 9.64648411 16.7815909 10.3535159 11.714 15.4221818 6.64640912 10.3535159 7.35359088 9.64648411 11.714 14.0078182"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_m_black</title><g fill="none" fill-rule="evenodd"><path d="M0 24h24V0H0z"/><path fill="#000" fill-rule="nonzero" d="M16.074 9.646l.708.708-5.068 5.068-5.068-5.068.708-.708 4.36 4.362z"/></g></svg>

--- a/icons/ui/icon_arrow-down_m_white.svg
+++ b/icons/ui/icon_arrow-down_m_white.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"/><path fill="#FFF" d="M24 7.087l-1.082-.973L12 15.941 1.082 6.114 0 7.087l12 10.799z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_m_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-22.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-2" transform="translate(22.000000, 0.000000)">
+                    <polygon id="Fill-4" points="0 24 24 24 24 0 0 0"></polygon>
+                    <polygon id="Stroke-3" fill="#FFFFFF" fill-rule="nonzero" points="16.0744091 9.64648411 16.7815909 10.3535159 11.714 15.4221818 6.64640912 10.3535159 7.35359088 9.64648411 11.714 14.0078182"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_m_white.svg
+++ b/icons/ui/icon_arrow-down_m_white.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_m_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-22.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-2" transform="translate(22.000000, 0.000000)">
-                    <polygon id="Fill-4" points="0 24 24 24 24 0 0 0"></polygon>
-                    <polygon id="Stroke-3" fill="#FFFFFF" fill-rule="nonzero" points="16.0744091 9.64648411 16.7815909 10.3535159 11.714 15.4221818 6.64640912 10.3535159 7.35359088 9.64648411 11.714 14.0078182"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_m_black</title><g fill="none" fill-rule="evenodd"><path d="M0 24h24V0H0z"/><path fill="#FFF" fill-rule="nonzero" d="M16.074 9.646l.708.708-5.068 5.068-5.068-5.068.708-.708 4.36 4.362z"/></g></svg>

--- a/icons/ui/icon_arrow-down_s_black.svg
+++ b/icons/ui/icon_arrow-down_s_black.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_s_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(0.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group">
-                    <polygon id="Fill-2" points="0 18.0001 18 18.0001 18 0.0001 0 0.0001"></polygon>
-                    <polygon id="Stroke-1" fill="#000000" fill-rule="nonzero" points="12.1816466 6.87874661 12.8887534 7.58585339 9.0002 11.4744068 5.11164661 7.58585339 5.81875339 6.87874661 9.0002 10.0601932"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_s_black</title><g fill="none" fill-rule="evenodd"><path d="M0 18h18V0H0z"/><path fill="#000" fill-rule="nonzero" d="M12.182 6.879l.707.707L9 11.474 5.112 7.586l.707-.707L9 10.06z"/></g></svg>

--- a/icons/ui/icon_arrow-down_s_black.svg
+++ b/icons/ui/icon_arrow-down_s_black.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="none" fill-rule="evenodd"><path d="M0 0h16v16H0z"/><path fill="#0B1F35" fill-rule="nonzero" d="M7.646 9.47h.708l-4-4-.708.707 4 4L8 10.53l.354-.353 4-4-.708-.707z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_s_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(0.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group">
+                    <polygon id="Fill-2" points="0 18.0001 18 18.0001 18 0.0001 0 0.0001"></polygon>
+                    <polygon id="Stroke-1" fill="#000000" fill-rule="nonzero" points="12.1816466 6.87874661 12.8887534 7.58585339 9.0002 11.4744068 5.11164661 7.58585339 5.81875339 6.87874661 9.0002 10.0601932"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_s_white.svg
+++ b/icons/ui/icon_arrow-down_s_white.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_s_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(0.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group">
-                    <polygon id="Fill-2" points="0 18.0001 18 18.0001 18 0.0001 0 0.0001"></polygon>
-                    <polygon id="Stroke-1" fill="#FFFFFF" fill-rule="nonzero" points="12.1816466 6.87874661 12.8887534 7.58585339 9.0002 11.4744068 5.11164661 7.58585339 5.81875339 6.87874661 9.0002 10.0601932"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_s_black</title><g fill="none" fill-rule="evenodd"><path d="M0 18h18V0H0z"/><path fill="#FFF" fill-rule="nonzero" d="M12.182 6.879l.707.707L9 11.474 5.112 7.586l.707-.707L9 10.06z"/></g></svg>

--- a/icons/ui/icon_arrow-down_s_white.svg
+++ b/icons/ui/icon_arrow-down_s_white.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="19" height="18" viewBox="0 0 19 18"><g fill="none" fill-rule="evenodd"><path d="M1 0h18v18H1z"/><path fill="#FFF" d="M18.914 5.316l-.811-.73-8.189 7.37-8.188-7.37-.812.73 9 8.099z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_s_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(0.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group">
+                    <polygon id="Fill-2" points="0 18.0001 18 18.0001 18 0.0001 0 0.0001"></polygon>
+                    <polygon id="Stroke-1" fill="#FFFFFF" fill-rule="nonzero" points="12.1816466 6.87874661 12.8887534 7.58585339 9.0002 11.4744068 5.11164661 7.58585339 5.81875339 6.87874661 9.0002 10.0601932"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_xl_black.svg
+++ b/icons/ui/icon_arrow-down_xl_black.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_xl_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-85.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-4" transform="translate(85.000000, 0.000000)">
-                    <polygon id="Fill-8" points="0 36 36 36 36 0 0 0"></polygon>
-                    <polygon id="Stroke-7" fill="#000000" fill-rule="nonzero" points="18.071975 20.3629682 24.7894716 13.6464216 25.4965284 14.3535784 18.072025 21.7770318 10.6464966 14.3536034 11.3535034 13.6463966"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_xl_black</title><g fill="none" fill-rule="evenodd"><path d="M0 36h36V0H0z"/><path fill="#000" fill-rule="nonzero" d="M18.072 20.363l6.717-6.717.708.708-7.425 7.423-7.426-7.423.708-.708z"/></g></svg>

--- a/icons/ui/icon_arrow-down_xl_black.svg
+++ b/icons/ui/icon_arrow-down_xl_black.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_xl_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-85.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-4" transform="translate(85.000000, 0.000000)">
+                    <polygon id="Fill-8" points="0 36 36 36 36 0 0 0"></polygon>
+                    <polygon id="Stroke-7" fill="#000000" fill-rule="nonzero" points="18.071975 20.3629682 24.7894716 13.6464216 25.4965284 14.3535784 18.072025 21.7770318 10.6464966 14.3536034 11.3535034 13.6463966"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_xl_white.svg
+++ b/icons/ui/icon_arrow-down_xl_white.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_xl_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-85.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-4" transform="translate(85.000000, 0.000000)">
-                    <polygon id="Fill-8" points="0 36 36 36 36 0 0 0"></polygon>
-                    <polygon id="Stroke-7" fill="#FFFFFF" fill-rule="nonzero" points="18.071975 20.3629682 24.7894716 13.6464216 25.4965284 14.3535784 18.072025 21.7770318 10.6464966 14.3536034 11.3535034 13.6463966"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_xl_black</title><g fill="none" fill-rule="evenodd"><path d="M0 36h36V0H0z"/><path fill="#FFF" fill-rule="nonzero" d="M18.072 20.363l6.717-6.717.708.708-7.425 7.423-7.426-7.423.708-.708z"/></g></svg>

--- a/icons/ui/icon_arrow-down_xl_white.svg
+++ b/icons/ui/icon_arrow-down_xl_white.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_xl_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-85.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-4" transform="translate(85.000000, 0.000000)">
+                    <polygon id="Fill-8" points="0 36 36 36 36 0 0 0"></polygon>
+                    <polygon id="Stroke-7" fill="#FFFFFF" fill-rule="nonzero" points="18.071975 20.3629682 24.7894716 13.6464216 25.4965284 14.3535784 18.072025 21.7770318 10.6464966 14.3536034 11.3535034 13.6463966"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_xxl_black.svg
+++ b/icons/ui/icon_arrow-down_xxl_black.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_xxl_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-125.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-5" transform="translate(125.000000, 0.000000)">
+                    <polygon id="Fill-10" points="0 48 48 48 48 0 0 0"></polygon>
+                    <polygon id="Stroke-9" fill="#000000" fill-rule="nonzero" points="32.5014466 18.6464466 33.2085534 19.3535534 23.4269812 29.1351255 13.6464279 19.3535346 14.3535721 18.6464654 23.4270188 27.7208745"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_xxl_black.svg
+++ b/icons/ui/icon_arrow-down_xxl_black.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_xxl_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-125.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-5" transform="translate(125.000000, 0.000000)">
-                    <polygon id="Fill-10" points="0 48 48 48 48 0 0 0"></polygon>
-                    <polygon id="Stroke-9" fill="#000000" fill-rule="nonzero" points="32.5014466 18.6464466 33.2085534 19.3535534 23.4269812 29.1351255 13.6464279 19.3535346 14.3535721 18.6464654 23.4270188 27.7208745"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_xxl_black</title><g fill="none" fill-rule="evenodd"><path d="M0 48h48V0H0z"/><path fill="#000" fill-rule="nonzero" d="M32.501 18.646l.708.708-9.782 9.781-9.78-9.781.707-.708 9.073 9.075z"/></g></svg>

--- a/icons/ui/icon_arrow-down_xxl_white.svg
+++ b/icons/ui/icon_arrow-down_xxl_white.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icon_arrow-down_xxl_black</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-125.000000, -65.000000)" id="arrow-down">
+            <g transform="translate(0.000000, 65.000000)">
+                <g id="Group-5" transform="translate(125.000000, 0.000000)">
+                    <polygon id="Fill-10" points="0 48 48 48 48 0 0 0"></polygon>
+                    <polygon id="Stroke-9" fill="#FFFFFF" fill-rule="nonzero" points="32.5014466 18.6464466 33.2085534 19.3535534 23.4269812 29.1351255 13.6464279 19.3535346 14.3535721 18.6464654 23.4270188 27.7208745"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/icons/ui/icon_arrow-down_xxl_white.svg
+++ b/icons/ui/icon_arrow-down_xxl_white.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icon_arrow-down_xxl_black</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-125.000000, -65.000000)" id="arrow-down">
-            <g transform="translate(0.000000, 65.000000)">
-                <g id="Group-5" transform="translate(125.000000, 0.000000)">
-                    <polygon id="Fill-10" points="0 48 48 48 48 0 0 0"></polygon>
-                    <polygon id="Stroke-9" fill="#FFFFFF" fill-rule="nonzero" points="32.5014466 18.6464466 33.2085534 19.3535534 23.4269812 29.1351255 13.6464279 19.3535346 14.3535721 18.6464654 23.4270188 27.7208745"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><title>icon_arrow-down_xxl_black</title><g fill="none" fill-rule="evenodd"><path d="M0 48h48V0H0z"/><path fill="#FFF" fill-rule="nonzero" d="M32.501 18.646l.708.708-9.782 9.781-9.78-9.781.707-.708 9.073 9.075z"/></g></svg>


### PR DESCRIPTION
Чтобы поправить проблему в селектах и меню у корпоратов, поправил иконки стрелок. Заодно добавил остальные размеры.
<img width="731" alt="screen shot 2018-01-17 at 23 24 07" src="https://user-images.githubusercontent.com/12576122/35065217-ad450f86-fbdd-11e7-80c8-b38b53ebbb9b.png">
